### PR TITLE
Fixes and homepage link support.

### DIFF
--- a/europecv2013.cls
+++ b/europecv2013.cls
@@ -381,6 +381,7 @@
 \ecvtelephone{}
 \ecvemail{}
 \ecvlinkedin{}
+\ecvhomepage{}
 \ecvgender{}
 \ecvdateofbirth{}
 \ecvnationality{}
@@ -405,6 +406,9 @@ $\begin{array}{@{}l}\includegraphics[width=\ecv@iconwidth]{ic_email}\end{array}$
 \fi
 \ifx\@empty\ecv@linkedin\else
 $\begin{array}{@{}l}\includegraphics[width=\ecv@iconwidth]{ic_linkedin}\end{array}$\ecv@linkedin\par\vspace{10pt}
+\fi
+\ifx\@empty\ecv@homepage\else
+$\begin{array}{@{}l}\includegraphics[width=\ecv@iconwidth]{ic_url}\end{array}$\ecv@homepage\par\vspace{10pt}
 \fi
 \ifx\@empty\ecv@gender
 	\ifx\@empty\ecv@birth

--- a/templates/cv_template_en.tex
+++ b/templates/cv_template_en.tex
@@ -9,7 +9,8 @@
 \ecvaddress{Replace with house number, street name, city, postcode, country}
 \ecvtelephone[Replace with telephone number]{Replace with mobile number}
 \ecvemail{State e-mail address}
-\ecvlinkedin{\href{Sostituire con url al profilo linkedin}{LinkedIn public profile URL without ``http://''}}
+\ecvlinkedin{\href{LinkedIn public profile URL}{LinkedIn public profile URL without ``http://''}}
+%\ecvhomepage{\href{Homepage URL}{Homepage URL without ``http://''}}
 \ecvgender{Enter sex}
 \ecvdateofbirth{dd/mm/yyyy}
 \ecvnationality{Enter nationality/-ies}

--- a/templates/cv_template_it.tex
+++ b/templates/cv_template_it.tex
@@ -10,6 +10,7 @@
 \ecvtelephone[Sostituire con numero telefonico]{Sostituire con telefono cellulare}
 \ecvemail{Sostituire con indirizzo e-mail }
 \ecvlinkedin{\href{Sostituire con url al profilo linkedin}{Sostituire con url al profilo linkedin senza http://}}
+%\ecvhomepage{\href{Sostituire con url al pagina personale}{Sostituire con url al pagina personale senza http://}}
 \ecvgender{Indicare il sesso}
 \ecvdateofbirth{gg/mm/aaaa}
 \ecvnationality{Indicare la nazionalità}


### PR DESCRIPTION
I have fixed several things – option utf8 was setting encoding to utf8x (with which the document won't compile correctly if there are characters with accents in some of the headings). So I have modified option utf8 to actually set the encoding to utf8. It is still possible to set utf8x by using option utf8x.

I have fixed the support for specifying homepage links. I have also added examples to the template files.

I have fixed a minor problem where babel was set to load italian instead of english in the english template.
